### PR TITLE
Batch up the trim prob calculations

### DIFF
--- a/gestalt/ancestral_events_finder.py
+++ b/gestalt/ancestral_events_finder.py
@@ -20,7 +20,6 @@ def annotate_ancestral_states(tree: CellLineageTree, bcode_meta: BarcodeMetadata
             node.add_feature("anc_state", AncState.create_for_observed_allele(node.allele_events, bcode_meta))
         elif node.is_root():
             node.add_feature("anc_state", AncState())
-            print(node.get_ascii(attributes=["anc_state"], show_internal=True))
         else:
             node_anc_state = get_possible_anc_states(node)
             node.add_feature("anc_state", node_anc_state)

--- a/gestalt/clt_likelihood_estimator.py
+++ b/gestalt/clt_likelihood_estimator.py
@@ -24,7 +24,6 @@ class CLTLassoEstimator(CLTEstimator):
     """
     def __init__(
         self,
-        sess: Session,
         penalty_param: float,
         model: CLTLikelihoodModel,
         approximator: ApproximatorLB):
@@ -32,7 +31,6 @@ class CLTLassoEstimator(CLTEstimator):
         @param penalty_param: lasso penalty parameter
         @param model: initial CLT model params
         """
-        self.sess = sess
         self.penalty_param = penalty_param
         self.model = model
         self.approximator = approximator

--- a/gestalt/clt_likelihood_model.py
+++ b/gestalt/clt_likelihood_model.py
@@ -350,7 +350,7 @@ class CLTLikelihoodModel:
         return hazard_aways
 
     def get_hazard_away(self, tts: Tuple[TargetTract]):
-        return self.get_hazard_aways([tts])
+        return self.get_hazard_aways([tts])[0]
 
     def initialize_indel_cond_probs(self, singletons: List[Singleton]):
         """
@@ -358,6 +358,9 @@ class CLTLikelihoodModel:
 
         @return a dict mapping a singleton to its conditional probability
         """
+        if len(singletons) == 0:
+            return dict()
+
         targets = []
         long_statuses = []
         positions = []

--- a/gestalt/simulate_estimators.py
+++ b/gestalt/simulate_estimators.py
@@ -156,7 +156,7 @@ def main():
             approximator = ApproximatorLB(extra_steps = 2, anc_generations = 1, bcode_metadata = bcode_meta)
             init_model_params = CLTLikelihoodModel(pruned_clt, bcode_meta, sess)
             tf.global_variables_initializer().run()
-            lasso_est = CLTLassoEstimator(sess, 0, init_model_params, approximator)
+            lasso_est = CLTLassoEstimator(0, init_model_params, approximator)
             st_time = time.time()
             log_lik = lasso_est.get_log_likelihood(init_model_params, get_grad=True)
             print("TIME", time.time() - st_time)


### PR DESCRIPTION
Batching up the trim probability calculations should make things faster

Tree with 50 leaves: 6 seconds for tensorflow to get all the numbers needed, another 6 seconds to string together all the numbers and calculate the likelihood.

Next PR: actually get gradients.