### PR TITLE
collapsed observed nodes are still observed

### DIFF
--- a/gestalt/ancestral_events_finder.py
+++ b/gestalt/ancestral_events_finder.py
@@ -16,7 +16,7 @@ def annotate_ancestral_states(tree: CellLineageTree, bcode_meta: BarcodeMetadata
     Find all possible events in the internal nodes.
     """
     for node in tree.traverse("postorder"):
-        if node.is_leaf():
+        if node.observed:
             node.add_feature("anc_state", AncState.create_for_observed_allele(node.allele_events, bcode_meta))
         elif node.is_root():
             node.add_feature("anc_state", AncState())

--- a/gestalt/approximator.py
+++ b/gestalt/approximator.py
@@ -67,7 +67,7 @@ class ApproximatorLB:
                 node.add_feature("state_sum", StateSum([TractRepr()]))
             else:
                 transition_graph_dict, state_sum = self._get_branch_state_sum_transitions(node)
-                if node.is_leaf():
+                if node.observed:
                     state_sum = StateSum.create_for_observed_allele(node.allele_events, self.bcode_meta)
                 node.add_feature("state_sum", state_sum)
                 node.add_feature("transition_graph_dict", transition_graph_dict)

--- a/gestalt/cell_lineage_tree.py
+++ b/gestalt/cell_lineage_tree.py
@@ -27,7 +27,6 @@ class CellLineageTree(TreeNode):
     Class can be used for storing information about the true cell lineage tree and can be
     used for storing the estimate of the cell lineage tree.
     """
-
     def __init__(self,
                  allele: Allele = None,
                  allele_events: AlleleEvents = None,
@@ -264,3 +263,25 @@ class CellLineageTree(TreeNode):
                 break
             anc = anc.up
         return anc
+
+    @staticmethod
+    def convert(node: TreeNode,
+                 allele: Allele = None,
+                 allele_events: AlleleEvents = None,
+                 cell_state: CellState = None,
+                 dist: float = 0,
+                 dead: bool = False,
+                 n_id: int = None,
+                 abundance: int = 1):
+        new_node = CellLineageTree(
+                 allele,
+                 allele_events,
+                 cell_state,
+                 dist,
+                 dead,
+                 n_id,
+                 abundance)
+        for k in node.features:
+            if k not in new_node.features:
+                new_node.add_feature(k, getattr(node, k))
+        return new_node

--- a/gestalt/clt_estimator.py
+++ b/gestalt/clt_estimator.py
@@ -75,11 +75,11 @@ class CLTParsimonyEstimator(CLTEstimator):
                                          event.insert_str) for event in events])
             cell_state = None if not c.is_leaf() else processed_obs[c.name]
             cell_abundance = 0 if not c.is_leaf() else processed_abund[c.name]
-            child_clt = CellLineageTree(child_allele,
+            child_clt = CellLineageTree.convert(c,
+                                        allele=child_allele,
                                         cell_state=cell_state,
                                         abundance=cell_abundance,
                                         dist=branch_length)
-
             clt.add_child(child_clt)
             self._do_convert(child_clt, c, event_list, processed_obs, processed_abund)
 
@@ -92,7 +92,8 @@ class CLTParsimonyEstimator(CLTEstimator):
         Make a regular TreeNode to a Cell lineage tree
         """
         # TODO: update cell state maybe in the future?
-        clt = CellLineageTree(
+        clt = CellLineageTree.convert(
+                tree,
                 Allele(self.orig_barcode, self.bcode_meta),
                 cell_state=None)
         self._do_convert(clt, tree, event_list, processed_obs, processed_abund)
@@ -121,6 +122,7 @@ class CLTParsimonyEstimator(CLTEstimator):
                 use_cell_state=use_cell_state)
         cmd = ["rm -f outfile outtree && %s < mix.cfg" % self.mix_path]
         res = subprocess.call(cmd, shell=True)
+        # Check that mix ran properly
         assert (res == 0)
         # Parse the outfile -- these are still regular Tree, not CellLineageTrees
         # In the future, we can simultaneously build a cell lineage tree while parsing the
@@ -135,7 +137,7 @@ class CLTParsimonyEstimator(CLTEstimator):
         #       to see if there is an equiv tree.
         uniq_trees = []
         for t in trees:
-            collapsed_est_tree = CollapsedTree.collapse(t, collapse_zero_lens=True)
+            collapsed_est_tree = CollapsedTree.collapse_zero_lens(t)
             if len(uniq_trees) == 0:
                 uniq_trees.append(collapsed_est_tree)
             else:

--- a/gestalt/clt_observer.py
+++ b/gestalt/clt_observer.py
@@ -24,6 +24,9 @@ class ObservedAlignedSeq:
         self.cell_state = cell_state
         self.abundance = abundance
 
+    def __str__(self):
+        return str(self.allele_events)
+
 
 class CLTObserver:
     def __init__(self,
@@ -103,7 +106,9 @@ class CLTObserver:
 
         if give_pruned_clt:
             # Collapse the tree
-            clt = CollapsedTree.collapse(clt, collapse_same_ancestral=True)
+            clt = CollapsedTree.collapse_same_ancestral(
+                    clt,
+                    feature_name="observed")
 
             return list(observations.values()), clt
         else:

--- a/gestalt/collapsed_tree.py
+++ b/gestalt/collapsed_tree.py
@@ -3,42 +3,75 @@ import numpy as np
 
 class CollapsedTree:
     @staticmethod
-    def collapse(
-            raw_tree: TreeNode,
-            collapse_zero_lens=False,
-            collapse_zero_leaves=False,
-            collapse_same_ancestral=False,
-            collapse_first_appear=False):
+    def _preprocess(raw_tree:TreeNode):
         tree = raw_tree.copy()
         tree.ladderize()
-        if collapse_zero_lens or collapse_zero_leaves:
-            # first remove zero-length edges
-            iterable_tree = tree.get_descendants(strategy='postorder') if collapse_zero_lens else tree
-            for node in iterable_tree:
-                if node.dist == 0:
-                    # TODO: one day we might want to think about collapsing only if the cell states are the same
-                    node.up.name = node.name
-                    node.delete(prevent_nondicotomic=False)
+        return tree
 
-        if collapse_same_ancestral:
-            # collapse if ancestor node has exactly the same events
-            for node in tree.get_descendants(strategy='postorder'):
-                if not node.is_root() and node.allele_events.events == node.up.allele_events.events:
+    @staticmethod
+    def collapse_zero_lens(raw_tree: TreeNode, feature_name: str = "observed"):
+        tree = CollapsedTree._preprocess(raw_tree)
+        # remove zero-length edges
+        for node in tree.get_descendants(strategy='postorder'):
+            if not hasattr(node, feature_name):
+                node.add_feature(feature_name, node.is_leaf())
+            if node.dist == 0:
+                # TODO: one day we might want to think about collapsing only if the cell states are the same
+                up_node = node.up
+                up_node.name = node.name
+                node.delete(prevent_nondicotomic=False)
+                up_node.add_feature(feature_name, getattr(node, feature_name))
+        print(tree.get_ascii(attributes=["observed"], show_internal=True))
+        return tree
+
+    @staticmethod
+    def collapse_zero_leaves(raw_tree: TreeNode):
+        tree = CollapsedTree._preprocess(raw_tree)
+        # remove zero-length edges to leaves
+        for node in tree:
+            if node.dist == 0:
+                # TODO: one day we might want to think about collapsing only if the cell states are the same
+                node.up.name = node.name
+                node.delete(prevent_nondicotomic=False)
+        return tree
+
+    @staticmethod
+    def collapse_same_ancestral(raw_tree: TreeNode, feature_name: str = "observed"):
+        """
+        @param feature_name: This feature will be attached to each node
+                            The leaf nodes will have this feature be true
+                            When collapsing leaf nodes into the tree, the upper node will
+                            keep this feature. This is useful for understanding which nodes
+                            were collapsed from the leaves.
+        """
+        tree = CollapsedTree._preprocess(raw_tree)
+        # collapse if ancestor node has exactly the same events
+        for node in tree.get_descendants(strategy='postorder'):
+            if not hasattr(node, feature_name):
+                node.add_feature(feature_name, node.is_leaf())
+            if not node.is_root():
+                up_node = node.up
+                if node.allele_events.events == node.up.allele_events.events:
                     node.delete(prevent_nondicotomic=False, preserve_branch_length=True)
+                    up_node.add_feature(feature_name, getattr(node, feature_name))
+        return tree
 
+
+    @staticmethod
+    def collapse_first_appear(raw_tree: TreeNode, feature_name: str = "observed"):
+        tree = CollapsedTree._preprocess(raw_tree)
         # collapse to subtree to first appearance of each leaf
-        if collapse_first_appear:
-            did_something = True
-            while did_something:
-                did_something = False
-                for leaf in tree:
-                    if not leaf.is_root() and leaf.allele_events.events == leaf.up.allele_events.events:
-                        # There is no branch length to preserve since this is a leaf...
-                        leaf.delete(prevent_nondicotomic=False, preserve_branch_length=False)
-                        did_something = True
+        did_something = True
+        while did_something:
+            did_something = False
+            for leaf in tree:
+                if not leaf.is_root() and leaf.allele_events.events == leaf.up.allele_events.events:
+                    # There is no branch length to preserve since this is a leaf...
+                    leaf.delete(prevent_nondicotomic=False, preserve_branch_length=False)
+                    did_something = True
 
-            for node in tree.get_descendants(strategy="postorder"):
-                if len(node.get_children()) == 1 and not node.is_root() and node.up.allele_events.events == node.allele_events.events:
-                    node.delete(prevent_nondicotomic=True, preserve_branch_length=True)
+        for node in tree.get_descendants(strategy="postorder"):
+            if len(node.get_children()) == 1 and not node.is_root() and node.up.allele_events.events == node.allele_events.events:
+                node.delete(prevent_nondicotomic=True, preserve_branch_length=True)
 
         return tree

--- a/gestalt/simulate_estimators.py
+++ b/gestalt/simulate_estimators.py
@@ -282,6 +282,7 @@ def main(args=sys.argv[1:]):
         logging.info("True tree topology, num leaves %d", len(true_tree))
         logging.info(true_tree.get_ascii(attributes=["allele_events"], show_internal=True))
         logging.info(true_tree.get_ascii(attributes=["cell_state"], show_internal=True))
+        logging.info(true_tree.get_ascii(attributes=["observed"], show_internal=True))
         logging.info("Number of uniq obs alleles %d", len(obs_leaves))
 
         # Fit parsimony trees -- only look at a couple trees per RF distance

--- a/gestalt/tests/test_clt_likelihood_calc.py
+++ b/gestalt/tests/test_clt_likelihood_calc.py
@@ -54,6 +54,7 @@ class LikelihoodCalculationTestCase(unittest.TestCase):
         # Create a branch with no events
         topology = CellLineageTree()
         child = CellLineageTree(allele_events=AlleleEvents([], num_targets=self.num_targets))
+        child.add_feature("observed", True)
         topology.add_child(child)
 
         branch_len = 0.1
@@ -92,6 +93,7 @@ class LikelihoodCalculationTestCase(unittest.TestCase):
         child = CellLineageTree(
                 allele_events=AlleleEvents([event], num_targets=self.num_targets))
         topology.add_child(child)
+        child.add_feature("observed", True)
 
         branch_len = 10
         model = self._create_model(topology, self.bcode_metadata, branch_len)
@@ -142,6 +144,7 @@ class LikelihoodCalculationTestCase(unittest.TestCase):
         child = CellLineageTree(
                 allele_events=AlleleEvents([event], num_targets=self.num_targets))
         topology.add_child(child)
+        child.add_feature("observed", True)
 
         branch_len = 10
         model = self._create_model(topology, self.bcode_metadata, branch_len)
@@ -202,6 +205,7 @@ class LikelihoodCalculationTestCase(unittest.TestCase):
                 allele_events=AlleleEvents([event], num_targets=self.num_targets))
         topology.add_child(child1)
         child1.add_child(child2)
+        child2.add_feature("observed", True)
 
         branch_len1 = 10
         branch_len2 = 5
@@ -289,6 +293,7 @@ class LikelihoodCalculationTestCase(unittest.TestCase):
         topology.add_child(child1)
         child1.add_child(child2)
         child2.add_child(child3)
+        child3.add_feature("observed", True)
 
         branch_len = 0.5
         model = self._create_model(topology, bcode_metadata, branch_len)


### PR DESCRIPTION
In the special case that a leaf node is collapsed up to an internal node, then we want to still treat this node as having only one possible ancestral state, i.e. the observed one.

This likelihood calculation code no longer checks leaves but checks if that node is observed.