### PR TITLE
correct rf dist calculations

### DIFF
--- a/gestalt/cell_lineage_tree.py
+++ b/gestalt/cell_lineage_tree.py
@@ -302,3 +302,31 @@ class CellLineageTree(TreeNode):
             if k not in new_node.features:
                 new_node.add_feature(k, getattr(node, k))
         return new_node
+
+    def get_robinson_foulds_collapsed(self, coll_tree2, attr1, attr2):
+        def make_fake_leaves(tree, attr):
+            for node in tree.traverse():
+                if getattr(node, attr) and not node.is_leaf():
+                    new_child = CellLineageTree.convert(
+                            node,
+                            node.allele_list,
+                            node.allele_events_list,
+                            node.cell_state,
+                            0)
+                    node.add_child(new_child)
+
+        tree1 = self.copy()
+        tree2 = coll_tree2.copy()
+        make_fake_leaves(tree1, attr1)
+        make_fake_leaves(tree2, attr2)
+        rf_dist_res = tree1.robinson_foulds(
+                tree2,
+                attr_t1=attr1,
+                attr_t2=attr2,
+                # Not only is this option buggy, I think we actually want the unrooted
+                # calculation -- we want to compare if the MRCAs of the two trees
+                # are the same. This means partitioning along internal edges and
+                # doing a symmetric difference of the sets of partitions.
+                expand_polytomies=False,
+                unrooted_trees=True)
+        return rf_dist_res[0], rf_dist_res[1]

--- a/gestalt/simulate_estimators.py
+++ b/gestalt/simulate_estimators.py
@@ -230,18 +230,10 @@ def get_parsimony_trees(obs_leaves, args, bcode_meta, true_tree, max_uniq_trees=
     # Sort the parsimony trees into their robinson foulds distance from the truth
     parsimony_tree_dict = {}
     for tree in parsimony_trees:
-        rf_dist_res = true_tree.robinson_foulds(
+        rf_dist, rf_dist_max = true_tree.get_robinson_foulds_collapsed(
                 tree,
-                attr_t1="allele_events_list_str",
-                attr_t2="allele_events_list_str",
-                # Not only is this option buggy, I think we actually want the unrooted
-                # calculation -- we want to compare if the MRCAs of the two trees
-                # are the same. This means partitioning along internal edges and
-                # doing a symmetric difference of the sets of partitions.
-                expand_polytomies=False,
-                unrooted_trees=True)
-        rf_dist_max = rf_dist_res[1]
-        rf_dist = rf_dist_res[0]
+                attr1="allele_events_list_str",
+                attr2="allele_events_list_str")
         logging.info("rf dist %d (max %d)", rf_dist, rf_dist_max)
         logging.info(tree.get_ascii(attributes=["allele_events_list_str"], show_internal=True))
         logging.info(tree.get_ascii(attributes=["observed"], show_internal=True))


### PR DESCRIPTION
append fake leaves to internal nodes that are observed.