### PR TITLE
add approximation for singleton-WCs internal nodes

### DIFF
--- a/gestalt/clt_likelihood_model.py
+++ b/gestalt/clt_likelihood_model.py
@@ -62,7 +62,7 @@ class CLTLikelihoodModel:
             assert self.root_node_id == 0
             self.num_nodes = self.topology.get_num_nodes()
         self.bcode_meta = bcode_meta
-        self.targ_stat_transitions_dict = TargetStatus.get_all_transitions(self.bcode_meta)
+        self.targ_stat_transitions_dict, _ = TargetStatus.get_all_transitions(self.bcode_meta)
 
         self.num_targets = bcode_meta.n_targets
 

--- a/gestalt/likelihood_scorer.py
+++ b/gestalt/likelihood_scorer.py
@@ -99,7 +99,8 @@ class LikelihoodScorer(ParallelWorker):
                 self.target_lam_pen)
 
         # Initialize with parameters such that the branch lengths are positive
-        res_model.initialize_branch_lens()
+        if 'branch_len_inners' not in self.init_model_params or 'branch_len_offsets_proportion' not in self.init_model_params:
+            res_model.initialize_branch_lens()
         full_init_model_params = res_model.get_vars_as_dict()
         for key, val in self.init_model_params.items():
             if key != "tot_time" and val.shape != full_init_model_params[key].shape:

--- a/gestalt/simulation_consistency/sconscript
+++ b/gestalt/simulation_consistency/sconscript
@@ -102,9 +102,11 @@ def run_MLE(env, outdir, c):
         '--topology-file ${SOURCES[1]}',
         '--true-model-file ${SOURCES[2]}',
         '--true-collapsed-tree-file ${SOURCES[3]}',
-        '--seed 400',
+        '--seed',
+	c['seed'] + 100,
         '--log-barr 0.001',
         '--target-lam-pen 10.0',
+        '--max-sum-states 50',
         '--max-iters 6000',
     ]
     return env.Command(

--- a/gestalt/simulation_one_barcode/sconscript
+++ b/gestalt/simulation_one_barcode/sconscript
@@ -137,6 +137,7 @@ def run_MLE(env, outdir, c):
         5.0,
         '--log-barr',
         0.001,
+        '--max-sum-states 50',
         '--max-iters 2000',
     ]
     return env.Command(

--- a/gestalt/target_status.py
+++ b/gestalt/target_status.py
@@ -213,9 +213,12 @@ class TargetStatus(tuple):
     @staticmethod
     def get_all_transitions(bcode_meta: BarcodeMetadata):
         """
-        @return Dict[start TargetStatus, Dict[end TargetStatus, List[TargetTract] that can be introduced to the start TargetStatus to create the end TargetStatus]
+        @return tuple of two Dicts:
+            1. Dict[start TargetStatus, Dict[end TargetStatus, List[TargetTract] that can be introduced to the start TargetStatus to create the end TargetStatus]
+            2. Dict[end TargetStatus, Set[start TargetStatus]]: maps each end target status to all the possible start target statuses (within one step)
         """
         target_status_transition_dict = dict()
+        target_status_inverse_transition_dict = dict()
         deact_targs = TargetDeactTract(0, bcode_meta.n_targets - 1)
         target_statuses = deact_targs.get_contained_target_statuses()
         for targ_stat in target_statuses:
@@ -228,5 +231,13 @@ class TargetStatus(tuple):
                     targ_stat_start_dict[new_targ_stat].append(target_tract)
                 else:
                     targ_stat_start_dict[new_targ_stat] = [target_tract]
+
+                # Also update the inverse dictionary -- maps new state to possible previous states
+                if new_targ_stat in target_status_inverse_transition_dict:
+                    target_status_inverse_transition_dict[new_targ_stat].add(targ_stat)
+                else:
+                    target_status_inverse_transition_dict[new_targ_stat] = set([targ_stat])
+
             target_status_transition_dict[targ_stat] = targ_stat_start_dict
-        return target_status_transition_dict
+
+        return target_status_transition_dict, target_status_inverse_transition_dict


### PR DESCRIPTION
we used to only approximate for leaves. but then my simulations ran into more crazy trees and we need to be able to deal with approximations in the internal nodes too. only doing approximations if the node has solely singleton-wcs in its upper bound.

I ran the MLE consistency simulation where the observed alleles required us to use an approximation and it looks like things are working relatively well:
```
initial tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.7347197121868241, 'mrca_spearman': 0.9697168424179076}
iter 19 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.6895502948355248, 'mrca_spearman': 0.9697168424179076}
iter 39 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.6448224733116432, 'mrca_spearman': 0.9697168424179076}
iter 59 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.6003209454523564, 'mrca_spearman': 0.9697168424179076}
iter 79 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.5599365068091662, 'mrca_spearman': 0.9697168424179076}
iter 99 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.5270093895754002, 'mrca_spearman': 0.9697168424179076}
iter 119 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.5011170513283062, 'mrca_spearman': 0.9697168424179076}
iter 139 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.47854205110785025, 'mrca_spearman': 0.9697168424179076}
iter 159 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.4573613573679299, 'mrca_spearman': 0.9697168424179076}
iter 179 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.4376241288694435, 'mrca_spearman': 0.9697168424179076}
iter 199 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.41962477394361986, 'mrca_spearman': 0.9697168424179076}
iter 219 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.40310913576732194, 'mrca_spearman': 0.9697168424179076}
iter 239 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.3873060289983884, 'mrca_spearman': 0.9697168424179076}
iter 259 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.3712934760516047, 'mrca_spearman': 0.9697168424179076}
iter 279 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.35432445152226966, 'mrca_spearman': 0.9936183138859546}
iter 299 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.33594331683131806, 'mrca_spearman': 0.9936183138859546}
iter 319 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.315942387689686, 'mrca_spearman': 0.9936183138859546}
iter 339 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.29429151516835106, 'mrca_spearman': 0.9782530822279244}
iter 359 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.2711418676830327, 'mrca_spearman': 0.9782530822279244}
iter 379 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.24689663601113726, 'mrca_spearman': 0.9782530822279244}
iter 399 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.22228369576432191, 'mrca_spearman': 0.9782530822279244}
iter 419 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.19838904232928767, 'mrca_spearman': 0.9782530822279244}
iter 439 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.17660506608621623, 'mrca_spearman': 0.9782530822279244}
iter 459 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.15841562699081163, 'mrca_spearman': 0.9782530822279244}
iter 479 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.14498294952550173, 'mrca_spearman': 0.9782530822279244}
iter 499 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.1366882428029013, 'mrca_spearman': 0.9936183138859546}
iter 519 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.13297046941974514, 'mrca_spearman': 0.9936183138859546}
iter 539 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.13264594093068788, 'mrca_spearman': 0.9936183138859546}
iter 559 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.13443805190744845, 'mrca_spearman': 0.9936183138859546}
iter 579 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.1373314774263946, 'mrca_spearman': 0.9936183138859546}
iter 599 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.14065732501597109, 'mrca_spearman': 0.9936183138859546}
iter 619 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.14402999899692218, 'mrca_spearman': 0.9936183138859546}
iter 639 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.14725216234144986, 'mrca_spearman': 0.9936183138859546}
iter 659 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.15023814300329535, 'mrca_spearman': 0.9936183138859546}
iter 679 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.15296306169096507, 'mrca_spearman': 0.9936183138859546}
iter 699 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.1554329924903841, 'mrca_spearman': 0.9936183138859546}
iter 719 tree dists: {'ete_rf_unroot': 0, 'ete_rf_root': 0, 'mrca': 0.15766770455234566, 'mrca_spearman': 0.9936183138859546}
```
