### PR TITLE
Correctly prune possible states to sum over

### DIFF
--- a/gestalt/analyze_gestalt/sconscript
+++ b/gestalt/analyze_gestalt/sconscript
@@ -87,8 +87,8 @@ def run_MLE(env, outdir, c):
         '--seed 100',
         '--log-barr 0.001',
         '--target-lam-pen 10.0',
-        '--max-sum-states 800',
-        '--max-extra-steps 10',
+        '--max-sum-states 20',
+        '--max-extra-steps 0',
         '--max-iters 0',
     ]
     return env.Command(

--- a/gestalt/clt_likelihood_estimator.py
+++ b/gestalt/clt_likelihood_estimator.py
@@ -87,6 +87,7 @@ class CLTPenalizedEstimator(CLTEstimator):
 
         prev_pen_log_lik = pen_log_lik[0]
         logging.info("initial penalized log lik %f, unpen log lik %f", pen_log_lik, log_lik)
+        print("initial penalized log lik obtained %f" % pen_log_lik)
         assert not np.isnan(pen_log_lik)
         train_history = [{
                     "iter": -1,


### PR DESCRIPTION
The pruning code was previously very buggy.

Also now the code actually calculates the minimum number of transition steps and then prunes based on max extra steps rather than using `max_extra` as the total maximum number of steps. This will allow us to handle datasets where some branches require a large number of cuts.